### PR TITLE
Inheritance support

### DIFF
--- a/src/Interactions.ts
+++ b/src/Interactions.ts
@@ -11,19 +11,17 @@ import * as types from './types';
  */
 export default class Interactions {
   mountPoint:string[];
-  initialState:any;
+  initialState:any = Object.create(null);
   // Set on the prototype, not instances.
   _interactionReducers:{[key:string]:types.Reducer};
   // This instance's reducers map, separate from _interactionReducer
   // so it can have a different type (or key in this map) than a base
   // class's reducer
-  _instanceInteractionReducers:{[key:string]:types.Reducer} = {};
+  _instanceInteractionReducers:{[key:string]:types.Reducer} = Object.create(null);
   // Maintains a mapping from @reducer function name to unique action type
-  _actionTypes:{[key:string]:string} = {};
+  _actionTypes:{[key:string]:string} = Object.create(null);
 
   constructor() {
-    this.initialState = Object.create(null);
-
     // Register the class as a property of the instance so it is "exported"
     // under normal use.
     this[this.constructor.name] = this.constructor;
@@ -80,10 +78,7 @@ export default class Interactions {
     this.prototype[name] = this._registerInteractionReducer(name, reducer);
   }
 
-  static _registerInteractionReducer(name:string, reducer:types.InteractionReducer, type?:string):types.PassthroughActionCreator {
-    if (!type) {
-      type = name;
-    }
+  static _registerInteractionReducer(name:string, reducer:types.InteractionReducer, type:string = name):types.PassthroughActionCreator {
 
     // Allow inheritance of interaction reducers.
     if (!Object.getOwnPropertyDescriptor(this.prototype, '_interactionReducers')) {

--- a/src/Interactions.ts
+++ b/src/Interactions.ts
@@ -18,8 +18,6 @@ export default class Interactions {
   // so it can have a different type (or key in this map) than a base
   // class's reducer
   _instanceInteractionReducers:{[key:string]:types.Reducer} = {};
-  // Maintains a mapping from @reducer function name to unique action type
-  _actionTypes:{[key:string]:string} = {};
 
   constructor() {
     this.initialState = Object.create(null);
@@ -41,7 +39,9 @@ export default class Interactions {
     // getting instantiated (vs a base class name)
     for (const key in this._interactionReducers) {
       // Make globally unique
-      const type = this._actionTypes[key] = uniqueType(`${this.constructor.name}:${key}`);
+      const type = uniqueType(`${this.constructor.name}:${key}`);
+      // Define a constant containing the complete action type as ALL_CAPS.
+      this[_.snakeCase(key).toUpperCase()] = type;
       this._instanceInteractionReducers[type] = this._interactionReducers[key];
     }
   }
@@ -83,9 +83,6 @@ export default class Interactions {
       type = name;
     }
 
-    // Define a constant containing the complete action type as ALL_CAPS.
-    this.prototype[_.snakeCase(name).toUpperCase()] = type;
-
     // Allow inheritance of interaction reducers.
     if (!Object.getOwnPropertyDescriptor(this.prototype, '_interactionReducers')) {
       this.prototype._interactionReducers = Object.create(this.prototype._interactionReducers || null);
@@ -95,7 +92,7 @@ export default class Interactions {
     this.prototype._interactionReducers[type] = reducer;
 
     return function actionCreator(...args:any[]):types.PassthroughAction {
-      return {type: this._actionTypes[type], args};
+      return {type: this[_.snakeCase(type).toUpperCase()], args};
     };
   }
 

--- a/src/Interactions.ts
+++ b/src/Interactions.ts
@@ -28,7 +28,6 @@ export default class Interactions {
     // under normal use.
     this[this.constructor.name] = this.constructor;
 
-    // TODO: What if this goes more levels deep?
     // Auto-bind all methods declared on the subclass to this instance.
     for (const name of Object.getOwnPropertyNames(Object.getPrototypeOf(this))) {
       if (name === 'constructor') continue;

--- a/src/Interactions.ts
+++ b/src/Interactions.ts
@@ -18,6 +18,8 @@ export default class Interactions {
   // so it can have a different type (or key in this map) than a base
   // class's reducer
   _instanceInteractionReducers:{[key:string]:types.Reducer} = {};
+  // Maintains a mapping from @reducer function name to unique action type
+  _actionTypes:{[key:string]:string} = {};
 
   constructor() {
     this.initialState = Object.create(null);
@@ -39,7 +41,7 @@ export default class Interactions {
     // getting instantiated (vs a base class name)
     for (const key in this._interactionReducers) {
       // Make globally unique
-      const type = uniqueType(`${this.constructor.name}:${key}`);
+      const type = this._actionTypes[key] = uniqueType(`${this.constructor.name}:${key}`);
       // Define a constant containing the complete action type as ALL_CAPS.
       this[_.snakeCase(key).toUpperCase()] = type;
       this._instanceInteractionReducers[type] = this._interactionReducers[key];
@@ -92,7 +94,7 @@ export default class Interactions {
     this.prototype._interactionReducers[type] = reducer;
 
     return function actionCreator(...args:any[]):types.PassthroughAction {
-      return {type: this[_.snakeCase(type).toUpperCase()], args};
+      return {type: this._actionTypes[type], args};
     };
   }
 

--- a/src/Interactions.ts
+++ b/src/Interactions.ts
@@ -14,7 +14,12 @@ export default class Interactions {
   initialState:any;
   // Set on the prototype, not instances.
   _interactionReducers:{[key:string]:types.Reducer};
+  // This instance's reducers map, separate from _interactionReducer
+  // so it can have a different type (or key in this map) than a base
+  // class's reducer
   _instanceInteractionReducers:{[key:string]:types.Reducer} = {};
+  // Maintains a mapping from @reducer function name to unique action type
+  _actionTypes:{[key:string]:string} = {};
 
   constructor() {
     this.initialState = Object.create(null);
@@ -34,14 +39,12 @@ export default class Interactions {
     this.reducer = _bind(this, this.reducer);
 
     // Add the class name to the action type, which we now know because it's
-    // getting instantiated
+    // getting instantiated (vs a base class name)
     for (const key in this._interactionReducers) {
-      this._instanceInteractionReducers[this._actionType(key)] = this._interactionReducers[key];
+      // Make globally unique
+      const type = this._actionTypes[key] = uniqueType(`${this.constructor.name}:${key}`);
+      this._instanceInteractionReducers[type] = this._interactionReducers[key];
     }
-  }
-
-  _actionType(key) {
-    return uniqueType(`${this.constructor.name}:${key}`);
   }
 
   /**
@@ -78,7 +81,7 @@ export default class Interactions {
 
   static _registerInteractionReducer(name:string, reducer:types.InteractionReducer, type?:string):types.PassthroughActionCreator {
     if (!type) {
-      type = name;
+      type = uniqueType(name);
     }
 
     // Define a constant containing the complete action type as ALL_CAPS.
@@ -93,7 +96,7 @@ export default class Interactions {
     this.prototype._interactionReducers[type] = reducer;
 
     return function actionCreator(...args:any[]):types.PassthroughAction {
-      return {type: this._actionType(type), args};
+      return {type: this._actionTypes[type], args};
     };
   }
 

--- a/src/Interactions.ts
+++ b/src/Interactions.ts
@@ -81,7 +81,7 @@ export default class Interactions {
 
   static _registerInteractionReducer(name:string, reducer:types.InteractionReducer, type?:string):types.PassthroughActionCreator {
     if (!type) {
-      type = uniqueType(name);
+      type = name;
     }
 
     // Define a constant containing the complete action type as ALL_CAPS.

--- a/test/unit/reducer.ts
+++ b/test/unit/reducer.ts
@@ -43,7 +43,7 @@ describe(`reducer`, () => {
     const instance = new Counter;
     const add:Function = instance.add;
 
-    expect(add().type).to.eql('FOO_BAR');
+    expect(add().type).to.eql('Counter:FOO_BAR');
     expect(instance.reducer(1, add())).to.eql(2);
     expect(instance.reducer(1, add(5))).to.eql(6);
   });

--- a/test/unit/reducer.ts
+++ b/test/unit/reducer.ts
@@ -61,14 +61,13 @@ describe(`reducer`, () => {
       subtract(scopedState:number, amount:number = 1):number {
         return scopedState - amount;
       }
-
     }
     const instance = new SpecificCounter;
     const add:Function = instance.add.bind(instance);
     const subtract:Function = instance.subtract.bind(instance);
 
-    expect(add().type).to.eql('SpecificCounter:add');
-    expect(subtract().type).to.eql('SpecificCounter:subtract');
+    expect(add().type).to.eql((<any>instance).ADD);
+    expect(subtract().type).to.eql((<any>instance).SUBTRACT);
     expect(instance.reducer(1, add())).to.eql(2);
     expect(instance.reducer(1, add(5))).to.eql(6);
     expect(instance.reducer(1, subtract())).to.eql(0);

--- a/test/unit/reducer.ts
+++ b/test/unit/reducer.ts
@@ -48,4 +48,31 @@ describe(`reducer`, () => {
     expect(instance.reducer(1, add(5))).to.eql(6);
   });
 
+  it(`Enables inheritance of interactions`, () => {
+    class Counter extends Interactions {
+      @reducer
+      add(scopedState:number, amount:number = 1):number {
+        return scopedState + amount;
+      }
+    }
+
+    class SpecificCounter extends Counter {
+      @reducer
+      subtract(scopedState:number, amount:number = 1):number {
+        return scopedState - amount;
+      }
+
+    }
+    const instance = new SpecificCounter;
+    const add:Function = instance.add.bind(instance);
+    const subtract:Function = instance.subtract.bind(instance);
+
+    expect(add().type).to.eql('SpecificCounter:add');
+    expect(subtract().type).to.eql('SpecificCounter:subtract');
+    expect(instance.reducer(1, add())).to.eql(2);
+    expect(instance.reducer(1, add(5))).to.eql(6);
+    expect(instance.reducer(1, subtract())).to.eql(0);
+    expect(instance.reducer(1, subtract(5))).to.eql(-4);
+  });
+
 });


### PR DESCRIPTION
If I have class A extends class B which extends Interaction, the reducer on class B all listened to the same action type, despite multiple instances of A.